### PR TITLE
Use gradle-build-action for Gradle builds

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
@@ -42,6 +42,10 @@ We recommend that you have a basic understanding of Java and the Gradle framewor
 
 ## Starting with a Gradle workflow template
 
+The easiest way to execute a Gradle build in your workflow is by using the `gradle/gradle-build-action` action provided by the Gradle organization on GitHub. The action takes care of invoking Gradle, collecting results, and caching state between job runs in a workflow. For more information see [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action).
+
+Using Gradle's `gradle/gradle-build-action` is the recommended way of using Gradle with GitHub Actions.
+
 {% data variables.product.prodname_dotcom %} provides a Gradle workflow template that will work for most Gradle-based Java projects. For more information, see the [Gradle workflow template](https://github.com/actions/starter-workflows/blob/main/ci/gradle.yml).
 
 To get started quickly, you can choose the preconfigured Gradle template when you create a new workflow. For more information, see the "[{% data variables.product.prodname_actions %} quickstart](/actions/quickstart)."
@@ -69,7 +73,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
         with:
           arguments: build
 ```
@@ -79,7 +83,7 @@ This workflow performs the following steps:
 1. The `checkout` step downloads a copy of your repository on the runner.
 2. The `setup-java` step configures the Java 11 JDK by Adoptium.
 3. The "Validate Gradle wrapper" step validates the checksums of Gradle Wrapper JAR files present in the source tree.
-4. The "Build with Gradle" step runs the `gradlew` wrapper script to ensure that your code builds, tests pass, and a package can be created.
+4. The "Build with Gradle" step runs the Gradle build to ensure that your code builds, tests pass, and a package can be created.
 
 The default workflow templates are excellent starting points when creating your build and test workflow, and you can customize the template to suit your project’s needs.
 
@@ -106,7 +110,7 @@ steps:
   - name: Validate Gradle wrapper
     uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
   - name: Run the Gradle package task
-    uses: gradle/gradle-build-action@v2
+    uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
     with:
       arguments: -b ci.gradle package
 ```
@@ -114,9 +118,9 @@ steps:
 
 ## Caching dependencies
 
-When using {% data variables.product.prodname_dotcom %}-hosted runners, your build dependencies can be cached to speed up your workflow runs. After a successful run, the `gradle-build-action` will cache important parts of the Gradle User Home directory on GitHub Actions infrastructure. In future workflow runs, the cache will be restored so that build scripts don't need to be recompiled and dependencies don't need to be downloaded from remote package repositories. 
+When using {% data variables.product.prodname_dotcom %}-hosted runners, your build dependencies can be cached to speed up your workflow runs. After a successful run, the `gradle/gradle-build-action` will cache important parts of the Gradle User Home directory on GitHub Actions infrastructure. In future workflow runs, the cache will be restored so that build scripts don't need to be recompiled and dependencies don't need to be downloaded from remote package repositories. 
 
-The `gradle-build-action` takes care of this caching transparently, and further configuration is not normally required.
+The `gradle/gradle-build-action` takes care of this caching transparently, and further configuration is not normally required.
 
 ## Packaging workflow data as artifacts
 
@@ -135,7 +139,7 @@ steps:
   - name: Validate Gradle wrapper
     uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
   - name: Build with Gradle
-    uses: gradle/gradle-build-action@v2
+    uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
     with:
       arguments: build
   - uses: actions/upload-artifact@v2

--- a/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
@@ -69,7 +69,9 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle
-        run: ./gradlew build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
 ```
 
 This workflow performs the following steps:
@@ -104,38 +106,17 @@ steps:
   - name: Validate Gradle wrapper
     uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
   - name: Run the Gradle package task
-    run: ./gradlew -b ci.gradle package
+    uses: gradle/gradle-build-action@v2
+    with:
+      arguments: -b ci.gradle package
 ```
 {% endraw %}
 
 ## Caching dependencies
 
-When using {% data variables.product.prodname_dotcom %}-hosted runners, you can cache your dependencies to speed up your workflow runs. After a successful run, your local Gradle package cache will be stored on GitHub Actions infrastructure. In future workflow runs, the cache will be restored so that dependencies don't need to be downloaded from remote package repositories. You can cache dependencies simply using the [`setup-java` action](https://github.com/marketplace/actions/setup-java-jdk) or can use [`cache` action](https://github.com/actions/cache) for custom and more advanced configuration. 
+When using {% data variables.product.prodname_dotcom %}-hosted runners, your build dependencies can be cached to speed up your workflow runs. After a successful run, the `gradle-build-action` will cache important parts of the Gradle User Home directory on GitHub Actions infrastructure. In future workflow runs, the cache will be restored so that build scripts don't need to be recompiled and dependencies don't need to be downloaded from remote package repositories. 
 
-{% raw %}
-```yaml{:copy}
-steps:
-  - uses: actions/checkout@v2
-  - name: Set up JDK 11
-    uses: actions/setup-java@v2
-    with:
-      java-version: '11'
-      distribution: 'adopt'
-      cache: gradle
-  - name: Validate Gradle wrapper
-    uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-  - name: Build with Gradle
-    run: ./gradlew build
-  - name: Cleanup Gradle Cache
-    # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-    # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-    run: |
-      rm -f ~/.gradle/caches/modules-2/modules-2.lock
-      rm -f ~/.gradle/caches/modules-2/gc.properties
-```
-{% endraw %}
-
-This workflow will save the contents of your local Gradle package cache, located in the `.gradle/caches` and `.gradle/wrapper` directories of the runner's home directory. The cache key will be the hashed contents of the gradle build files (including the Gradle wrapper properties file), so any changes to them will invalidate the cache.
+The `gradle-build-action` takes care of this caching transparently, and further configuration is not normally required.
 
 ## Packaging workflow data as artifacts
 
@@ -153,7 +134,10 @@ steps:
       distribution: 'adopt'
   - name: Validate Gradle wrapper
     uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-  - run: ./gradlew build
+  - name: Build with Gradle
+    uses: gradle/gradle-build-action@v2
+    with:
+      arguments: build
   - uses: actions/upload-artifact@v2
     with:
       name: Package

--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -32,6 +32,8 @@ We recommend that you have a basic understanding of workflow files and configura
 
 For more information about creating a CI workflow for your Java project with Gradle, see "[Building and testing Java with Gradle](/actions/language-and-framework-guides/building-and-testing-java-with-gradle)."
 
+The examples below use `gradle/gradle-build-action` action provided by the Gradle organization on GitHub. The action takes care of invoking Gradle, collecting results, and caching state between job runs in a workflow. For more information see [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action).
+
 You may also find it helpful to have a basic understanding of the following:
 
 - "[Working with the npm registry](/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)"
@@ -97,7 +99,9 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        run: gradle publish
+        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        with:
+          arguments: publish
         env:
           MAVEN_USERNAME: {% raw %}${{ secrets.OSSRH_USERNAME }}{% endraw %}
           MAVEN_PASSWORD: {% raw %}${{ secrets.OSSRH_TOKEN }}{% endraw %}
@@ -166,7 +170,9 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        run: gradle publish
+        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        with:
+          arguments: publish
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 ```
@@ -243,7 +249,9 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        run: gradle publish
+        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        with:
+          arguments: publish
         env: {% raw %}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
The `gradle-build-action` provides enhanced execution and caching functionality for Gradle. 

Improvements over directly invoking `./gradlew` include:
- Easier to run the workflow with a particular Gradle version
- More sophisticated and more efficient caching of Gradle User Home between invocations
- Detailed reporting of cache usage and cache configuration options
- Automatic capture of Build Scan links